### PR TITLE
Long lines support added

### DIFF
--- a/src/main/javacc/ObjC2.0.jj
+++ b/src/main/javacc/ObjC2.0.jj
@@ -19,6 +19,8 @@ import java.util.*;
  * @author Michael Hall - Based on Parnel SableCC ObjectiveC grammar and javacc C grammar
  *
  * Josh Kennedy - added CSTRING_LITERAL so parser doesn't die on CStrings.
+ * Paul Taykalo - added support for 0x literals, @compatibility_alias, and the $ character identifier
+ * Paul Taykalo - vertical tab (\v) and alert (\a) characters are added
  */
  
 public class ObjCParser 
@@ -174,6 +176,7 @@ SKIP : {
 |  "\n"
 |  "\r"
 |  "\f"
+|  "\\\n"    /* Special issue for long strings concatenation */
 |  "__weak"
 |  "__strong"
 |  "__attribute__"


### PR DESCRIPTION
'\' at the end of the line can be used, not only in preprocessor
definitions..
